### PR TITLE
fix: disable renounceOwnership

### DIFF
--- a/contracts/DocumentStore.sol
+++ b/contracts/DocumentStore.sol
@@ -34,4 +34,8 @@ contract DocumentStore is BaseDocumentStore, OwnableUpgradeable {
   function bulkRevoke(bytes32[] memory documents) public onlyOwner {
     return BaseDocumentStore._bulkRevoke(documents);
   }
+
+  function renounceOwnership() public virtual override onlyOwner {
+    revert("Ownership cannot be renounced");
+  }
 }

--- a/test/DocumentStore.js
+++ b/test/DocumentStore.js
@@ -375,4 +375,12 @@ describe("DocumentStore", async () => {
       expect(issued).to.be.false;
     });
   });
+
+  describe("Ownership", () => {
+    it("should revert when renounce ownership", async () => {
+      const tx = DocumentStoreInstance.renounceOwnership();
+
+      await expect(tx).to.be.rejectedWith("Ownership cannot be renounced");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
To disable the `renounceOwnership` function to prevent accidental renouncing of ownership.

## Changes
- Revert when call `renounceOwnership`

## Issues
- https://www.pivotaltracker.com/story/show/183445129