### PR TITLE
feat: add access control

### DIFF
--- a/contracts/BaseDocumentStore.sol
+++ b/contracts/BaseDocumentStore.sol
@@ -17,7 +17,7 @@ contract BaseDocumentStore is Initializable {
   event DocumentIssued(bytes32 indexed document);
   event DocumentRevoked(bytes32 indexed document);
 
-  function initialize(string memory _name) internal onlyInitializing {
+  function __BaseDocumentStore_init(string memory _name) internal onlyInitializing {
     version = "2.3.0";
     name = _name;
   }

--- a/contracts/DocumentStore.sol
+++ b/contracts/DocumentStore.sol
@@ -6,32 +6,31 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import "./BaseDocumentStore.sol";
+import "./base/DocumentStoreAccessControl.sol";
 
-contract DocumentStore is BaseDocumentStore, OwnableUpgradeable {
+contract DocumentStore is BaseDocumentStore, DocumentStoreAccessControl {
   constructor(string memory _name, address owner) {
     initialize(_name, owner);
   }
 
   function initialize(string memory _name, address owner) internal initializer {
-    require(owner != address(0), "Owner is required");
-    super.__Ownable_init();
-    super.transferOwnership(owner);
-    BaseDocumentStore.initialize(_name);
+    __DocumentStoreAccessControl_init(owner);
+    __BaseDocumentStore_init(_name);
   }
 
-  function issue(bytes32 document) public onlyOwner onlyNotIssued(document) {
+  function issue(bytes32 document) public onlyRole(ISSUER_ROLE) onlyNotIssued(document) {
     BaseDocumentStore._issue(document);
   }
 
-  function bulkIssue(bytes32[] memory documents) public onlyOwner {
+  function bulkIssue(bytes32[] memory documents) public onlyRole(ISSUER_ROLE) {
     BaseDocumentStore._bulkIssue(documents);
   }
 
-  function revoke(bytes32 document) public onlyOwner onlyNotRevoked(document) returns (bool) {
+  function revoke(bytes32 document) public onlyRole(REVOKER_ROLE) onlyNotRevoked(document) returns (bool) {
     return BaseDocumentStore._revoke(document);
   }
 
-  function bulkRevoke(bytes32[] memory documents) public onlyOwner {
+  function bulkRevoke(bytes32[] memory documents) public onlyRole(REVOKER_ROLE) {
     return BaseDocumentStore._bulkRevoke(documents);
   }
 }

--- a/contracts/DocumentStoreWithRevokeReasons.sol
+++ b/contracts/DocumentStoreWithRevokeReasons.sol
@@ -12,7 +12,12 @@ contract DocumentStoreWithRevokeReasons is DocumentStore {
 
   constructor(string memory _name, address owner) DocumentStore(_name, owner) {}
 
-  function revoke(bytes32 document, uint256 reason) public onlyOwner onlyNotRevoked(document) returns (bool) {
+  function revoke(bytes32 document, uint256 reason)
+    public
+    onlyRole(REVOKER_ROLE)
+    onlyNotRevoked(document)
+    returns (bool)
+  {
     revoke(document);
     revokeReason[document] = reason;
     emit DocumentRevokedWithReason(document, reason);

--- a/contracts/base/DocumentStoreAccessControl.sol
+++ b/contracts/base/DocumentStoreAccessControl.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+contract DocumentStoreAccessControl is AccessControlUpgradeable {
+  bytes32 public constant ISSUER_ROLE = keccak256("ISSUER_ROLE");
+  bytes32 public constant REVOKER_ROLE = keccak256("REVOKER_ROLE");
+
+  function __DocumentStoreAccessControl_init(address owner) internal onlyInitializing {
+    require(owner != address(0), "Owner is zero");
+    _setupRole(DEFAULT_ADMIN_ROLE, owner);
+    _setupRole(ISSUER_ROLE, owner);
+    _setupRole(REVOKER_ROLE, owner);
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { providers } from "ethers";
+import { providers, ethers } from "ethers";
 import { deploy, deployAndWait, connect } from "./index";
 import { DocumentStoreCreator__factory as DocumentStoreCreatorFactory } from "./contracts";
 
@@ -6,6 +6,10 @@ const provider = new providers.JsonRpcProvider();
 const signer = provider.getSigner();
 let account: string;
 let documentStoreCreatorAddressOverride: string;
+
+const adminRole = ethers.constants.HashZero;
+const issuerRole = ethers.utils.id("ISSUER_ROLE");
+const revokerRole = ethers.utils.id("REVOKER_ROLE");
 
 beforeAll(async () => {
   // Deploy an instance of DocumentStoreFactory on the new blockchain
@@ -25,8 +29,14 @@ describe("deploy", () => {
 describe("deployAndWait", () => {
   it("deploys a new DocumentStore contract", async () => {
     const instance = await deployAndWait("My Store", signer, { documentStoreCreatorAddressOverride });
-    const owner = await instance.owner();
-    expect(owner).toBe(account);
+
+    const hasAdminRole = await instance.hasRole(adminRole, account);
+    const hasIssuerRole = await instance.hasRole(issuerRole, account);
+    const hasRevokerRole = await instance.hasRole(revokerRole, account);
+    expect(hasAdminRole).toBe(true);
+    expect(hasIssuerRole).toBe(true);
+    expect(hasRevokerRole).toBe(true);
+
     const name = await instance.name();
     expect(name).toBe("My Store");
   });
@@ -37,8 +47,6 @@ describe("connect", () => {
     const { address } = await deployAndWait("My Store", signer, { documentStoreCreatorAddressOverride });
     console.log(address);
     const instance = await connect(address, signer);
-    const owner = await instance.owner();
-    expect(owner).toBe(account);
     const name = await instance.name();
     expect(name).toBe("My Store");
   });

--- a/test/DocumentStoreCreator.js
+++ b/test/DocumentStoreCreator.js
@@ -24,16 +24,17 @@ describe("DocumentStoreCreator", async () => {
       // Test for events emitted by factory
       const tx = await DocumentStoreCreatorInstance.deploy(config.INSTITUTE_NAME);
       const receipt = await tx.wait();
-      expect(receipt.events[2].args.creator).to.be.equal(
+      expect(receipt.events[3].args.creator).to.be.equal(
         Accounts[0].address,
         "Emitted contract creator does not match"
       );
       // Test correctness of deployed DocumentStore
-      const deployedDocumentStore = await DocumentStore.attach(receipt.events[2].args.instance);
+      const deployedDocumentStore = await DocumentStore.attach(receipt.events[3].args.instance);
       const name = await deployedDocumentStore.name();
       expect(name).to.be.equal(config.INSTITUTE_NAME, "Name of institute does not match");
-      const owner = await deployedDocumentStore.owner();
-      expect(owner).to.be.equal(Accounts[0].address, "Owner of deployed contract does not match creator");
+
+      const hasAdminRole = await deployedDocumentStore.hasRole(ethers.constants.HashZero, Accounts[0].address);
+      expect(hasAdminRole).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Summary
To support roles for admin, issuer and revoker like in Token Registry v4. The document store owner will have an admin role which enables one to issue, revoke and control the access of other admins, issuers and revokers through roles. Issuers can only issue documents. Revokers can only revoke documents.

## Changes
* Add access control

## Issues
- https://www.pivotaltracker.com/story/show/183445129
- #127 

## Releases
Channels: latest
