### PR TITLE
fix: invalid return in revoke function

### DIFF
--- a/contracts/BaseDocumentStore.sol
+++ b/contracts/BaseDocumentStore.sol
@@ -48,6 +48,8 @@ contract BaseDocumentStore is Initializable {
   function _revoke(bytes32 document) internal onlyNotRevoked(document) returns (bool) {
     documentRevoked[document] = block.number;
     emit DocumentRevoked(document);
+
+    return true;
   }
 
   function _bulkRevoke(bytes32[] memory documents) internal {

--- a/contracts/DocumentStoreWithRevokeReasons.sol
+++ b/contracts/DocumentStoreWithRevokeReasons.sol
@@ -21,6 +21,8 @@ contract DocumentStoreWithRevokeReasons is DocumentStore {
     revoke(document);
     revokeReason[document] = reason;
     emit DocumentRevokedWithReason(document, reason);
+
+    return true;
   }
 
   function bulkRevoke(bytes32[] memory documents, uint256 reason) public {


### PR DESCRIPTION
## Summary
Revoke for some reason isn't returning anything even though it has a return type. 

## Changes
* Fix invalid return in revoke function

## Issues
- https://www.pivotaltracker.com/story/show/183445129

## Releases
Channels: latest
