### PR TITLE
docs: update README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm install @govtechsg/document-store-ethers-v5
 
 ### Document Store
 
-For a complete list of functions, refer to [IDocumentStoreBatchable.sol](src/interfaces/IDocumentStoreBatchable.sol).
+For a complete list of functions, refer to [IDocumentStoreBatchable.sol](https://github.com/Open-Attestation/document-store/blob/master/src/interfaces/IDocumentStoreBatchable.sol).
 
 #### Issuing a document:
 
@@ -137,7 +137,7 @@ await tx.wait();
 
 ### Transferable Document Store
 
-For a complete list of functions, refer to [ITransferableDocumentStore.sol](src/interfaces/ITransferableDocumentStore.sol).
+For a complete list of functions, refer to [ITransferableDocumentStore.sol](https://github.com/Open-Attestation/document-store/blob/master/src/interfaces/ITransferableDocumentStore.sol).
 
 #### Issuing a transferable document:
 
@@ -253,13 +253,13 @@ Most EVM-based blockchains should support the document store contracts. For the 
 - Optimism
 
 > [!NOTE]
-> For a list of pre-configured network names for passing to `--network` during deployment, refer to the [foundry.toml](foundry.toml#L28) file.
+> For a list of pre-configured network names for passing to `--network` during deployment, refer to the [foundry.toml](https://github.com/Open-Attestation/document-store/blob/master/foundry.toml#L28) file.
 
 If you wish to deploy to a network not configured yet, you can add it to the `foundry.toml` file and pass the name of the network you've added to `--network` during deployment.
 
 ## Configuration
 
-Create a `.env` file based on [`.env.example`](.env.sample) and provide the information in it.
+Create a `.env` file based on [`.env.example`](https://github.com/Open-Attestation/document-store/blob/master/.env.sample) and provide the information in it.
 
 The `DEPLOYER_ADDRESS` is required to be the address of the deployer during deployment. The Etherscan API keys are only required if you plan to verify the contracts on their respective chains.
 


### PR DESCRIPTION
Relative links are causing an issue with the OA docs website when trying to build.
```
Error: Unable to build website for locale en.
    at tryToBuildLocale (/Users/lucasyap/Desktop/documentation-website/node_modules/@docusaurus/core/lib/commands/build.js:55:19)
    at async mapAsyncSequential (/Users/lucasyap/Desktop/documentation-website/node_modules/@docusaurus/utils/lib/jsUtils.js:44:24)
    at async Command.build (/Users/lucasyap/Desktop/documentation-website/node_modules/@docusaurus/core/lib/commands/build.js:82:21) {
  [cause]: Error: Docusaurus found broken links!
  
  Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
  Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
  
  Exhaustive list of all broken links found:
  
  - On source page path = /docs/lib-section/remote-files/document-store:
     -> linking to src/interfaces/IDocumentStoreBatchable.sol (resolved as: /docs/lib-section/remote-files/src/interfaces/IDocumentStoreBatchable.sol)
     -> linking to src/interfaces/ITransferableDocumentStore.sol (resolved as: /docs/lib-section/remote-files/src/interfaces/ITransferableDocumentStore.sol)
     -> linking to foundry.toml#L28 (resolved as: /docs/lib-section/remote-files/foundry.toml)
     -> linking to .env.sample (resolved as: /docs/lib-section/remote-files/.env.sample)
```