### PR TITLE
ci: codecov issue

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -8,6 +8,8 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/tests.yml
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   linters:
     name: Linters

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        required: true
 
 name: "Tests"
 
@@ -45,7 +48,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: test-coverage
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: true
+          token: ${{ secrets.codecov_token }}


### PR DESCRIPTION
## Summary

The codecode action v3 appears to have started failing today due to some issues with it receiving the token. A recent change on their end might have broken the action. This PR fixes this issue by passing the secret via the caller job.

## Changes

- Update codecov action to v4
- Pass secret via caller job

## Issues
- https://github.com/Open-Attestation/document-store/actions/runs/8702186715/job/23873590081
- https://github.com/Open-Attestation/document-store/actions/runs/8702202718/job/23879143321?pr=168
- https://github.com/codecov/codecov-action/issues/1359

