### PR TITLE
test: add test for multicall revoke mixture of root and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ const tx = await documentStore["revoke"]("0xDocumentRoot", "0xTargetHash", ["0xP
 await tx.wait();
 ```
 
+#### Revoking multiple documents:
+
+```typescript
+const documentStore = DocumentStore__factory.connect(documentStoreAddress, signer);
+const bulkRevokations = [
+  documentStore.interface.encodeFunctionData("revoke", ["0xDocRoot1"]),
+  documentStore.interface.encodeFunctionData("revoke", ["0xDocRoot2"])
+];
+const tx = await documentStore.multicall(bulkRevokations);
+await tx.wait();
+```
+
 ### Transferable Document Store
 
 For a complete list of functions, refer to [ITransferableDocumentStore.sol](https://github.com/Open-Attestation/document-store/blob/master/src/interfaces/ITransferableDocumentStore.sol).

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint": "^8.57.0",
         "forge-std": "github:foundry-rs/forge-std#v1.7.6",
         "hardhat": "^2.20.1",
-        "prettier": "^3.2.5",
+        "prettier": "^3.4.2",
         "prettier-plugin-solidity": "^1.3.1",
         "semantic-release": "^23.0.2",
         "solhint": "^4.1.1",
@@ -3048,7 +3048,8 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -7831,6 +7832,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -10941,9 +10943,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^8.57.0",
     "forge-std": "github:foundry-rs/forge-std#v1.7.6",
     "hardhat": "^2.20.1",
-    "prettier": "^3.2.5",
+    "prettier": "^3.4.2",
     "prettier-plugin-solidity": "^1.3.1",
     "semantic-release": "^23.0.2",
     "solhint": "^4.1.1",

--- a/test/DocumentStoreBatchable.t.sol
+++ b/test/DocumentStoreBatchable.t.sol
@@ -130,6 +130,22 @@ contract DocumentStoreBatchable_multicall_revoke_Test is DocumentStoreBatchable_
     bulkRevokeData[1] = abi.encodeCall(IDocumentStoreBatchable.revoke, (docRoot(), documents()[1], proofs()[1]));
     bulkRevokeData[2] = abi.encodeCall(IDocumentStoreBatchable.revoke, (docRoot(), documents()[2], proofs()[2]));
   }
+
+  function testMulticallRevokeMixDocumentAndRoot() public {
+    bytes[] memory bulkRevokeDocAndRootData = new bytes[](2);
+    bulkRevokeDocAndRootData[0] = abi.encodeCall(
+      IDocumentStoreBatchable.revoke,
+      (docRoot(), documents()[1], proofs()[1])
+    );
+    bulkRevokeDocAndRootData[1] = abi.encodeCall(IDocumentStore.revoke, docRoot());
+
+    vm.prank(revoker);
+    documentStore.multicall(bulkRevokeDocAndRootData);
+
+    assertTrue(documentStore.isRevoked(docRoot(), documents()[0], proofs()[0]));
+    assertTrue(documentStore.isRevoked(docRoot(), documents()[1], proofs()[1]));
+    assertTrue(documentStore.isRevoked(docRoot(), documents()[2], proofs()[2]));
+  }
 }
 
 contract DocumentStoreBatchable_isRevoked_Test is DocumentStoreBatchable_Initializer {


### PR DESCRIPTION
## Summary

This PR adds an example of using bulk revoke to the readme documentation and an additional test for bulk revoking a mix of calls for a single document and root hash.

## Changes

- Add test for bulk revoke with mix calls for single document and root hash
- Add bulk revoke example in readme documentation
- Bump prettier

